### PR TITLE
Update Caching Strategy for Template.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 tokio = { version = "1.35.0", features = ["full"] }
 dotenvy = "0.15.7"
-async-trait = "0.1.74"
+async-trait = "0.1.77"
 sea-orm = { version = "0.12.9", features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",

--- a/coop-service/src/domain/repositories/endpoint.rs
+++ b/coop-service/src/domain/repositories/endpoint.rs
@@ -7,4 +7,6 @@ pub trait EndpointRepository: Send + Sync {
     async fn get_mock(&self, endpoint_id: i32) -> Result<Option<EndpointDto>, &str>;
 
     async fn get_mocks(&self) -> Result<Vec<EndpointDto>, &str>;
+
+    async fn get_mocks_by_scope(&self, scope: &str) -> Result<Vec<EndpointDto>, &str>;
 }

--- a/coop-service/src/domain/services/endpoint.rs
+++ b/coop-service/src/domain/services/endpoint.rs
@@ -8,4 +8,5 @@ pub trait EndpointService: Sync + Send {
     async fn create_mock(&self, settings: CreateEndpointDto) -> Result<(), CustomError>;
     async fn get_mock(&self, id: i32) -> Result<Option<EndpointDto>, CustomError>;
     async fn get_mocks(&self) -> Result<Vec<EndpointDto>, CustomError>;
+    async fn get_mocks_by_scope(&self, scope: &str) -> Result<Vec<EndpointDto>, CustomError>;
 }

--- a/coop-service/src/services/endpoint.rs
+++ b/coop-service/src/services/endpoint.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use chrono::format;
+
 use crate::{
     domain::{
         models::endpoints::{CreateEndpointDto, EndpointDto},
@@ -51,7 +53,11 @@ impl EndpointService for EndpointServiceImpl {
     }
 
     async fn get_mocks_by_scope(&self, scope: &str) -> Result<Vec<EndpointDto>, CustomError> {
-        let result = self.settings_repository.get_mocks_by_scope(scope).await;
+        let scope_add_slash = format!("/{}", scope);
+        let result = self
+            .settings_repository
+            .get_mocks_by_scope(scope_add_slash.as_str())
+            .await;
 
         match result {
             Ok(endpoints) => Ok(endpoints),

--- a/coop-service/src/services/endpoint.rs
+++ b/coop-service/src/services/endpoint.rs
@@ -49,4 +49,13 @@ impl EndpointService for EndpointServiceImpl {
             Err(err) => Err(errors::CustomError::ServiceError(err.to_string())),
         }
     }
+
+    async fn get_mocks_by_scope(&self, scope: &str) -> Result<Vec<EndpointDto>, CustomError> {
+        let result = self.settings_repository.get_mocks_by_scope(scope).await;
+
+        match result {
+            Ok(endpoints) => Ok(endpoints),
+            Err(err) => Err(CustomError::ServiceError(err.to_string())),
+        }
+    }
 }

--- a/web-api/src/api/mocks/mod.rs
+++ b/web-api/src/api/mocks/mod.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use endpoint_handler::{caching::TemplateCaching, endpoint_template::Template};
 use poem::{handler, http::StatusCode, web::Data, IntoResponse, Request};
 
-use crate::utils::mock_handler::MockEndpointsHandler;
+use crate::utils::mock_handler::DatabaseMockHandlerImpl;
 
 #[handler]
 pub async fn handle_mock_request(
     req: &Request,
-    mocks_handler: Data<&Arc<MockEndpointsHandler>>,
+    mocks_handler: Data<&Arc<DatabaseMockHandlerImpl>>,
 ) -> impl IntoResponse {
     let path = req.uri().path();
     let mocks_handler = mocks_handler.clone();

--- a/web-api/src/api/mocks/mod.rs
+++ b/web-api/src/api/mocks/mod.rs
@@ -1,12 +1,12 @@
 use poem::{handler, http::StatusCode, web::Data, IntoResponse, Request};
 use std::sync::Arc;
 
-use crate::utils::mock_handler::MockEndpointHandler;
+use crate::utils::mock_handler::{DatabaseMockHandlerImpl, MockEndpointHandler};
 
 #[handler]
 pub async fn handle_mock_request(
     req: &Request,
-    mocks_handler: Data<&Arc<dyn MockEndpointHandler>>,
+    mocks_handler: Data<&Arc<DatabaseMockHandlerImpl>>,
 ) -> impl IntoResponse {
     let mocks_handler = mocks_handler.clone();
 

--- a/web-api/src/api/mocks/mod.rs
+++ b/web-api/src/api/mocks/mod.rs
@@ -1,24 +1,20 @@
+use poem::{handler, http::StatusCode, web::Data, IntoResponse, Request};
 use std::sync::Arc;
 
-use endpoint_handler::{caching::TemplateCaching, endpoint_template::Template};
-use poem::{handler, http::StatusCode, web::Data, IntoResponse, Request};
-
-use crate::utils::mock_handler::DatabaseMockHandlerImpl;
+use crate::utils::mock_handler::MockEndpointHandler;
 
 #[handler]
 pub async fn handle_mock_request(
     req: &Request,
-    mocks_handler: Data<&Arc<DatabaseMockHandlerImpl>>,
+    mocks_handler: Data<&Arc<dyn MockEndpointHandler>>,
 ) -> impl IntoResponse {
-    let path = req.uri().path();
     let mocks_handler = mocks_handler.clone();
 
-    let match_template = mocks_handler
-        .caching
-        .find_template(path, req.method().as_str());
+    let response = mocks_handler.handle_mock_request(req).await;
 
-    match match_template {
-        Some(template) => template.into_response(),
-        None => StatusCode::NOT_FOUND.into_response(),
+    if response.is_none() {
+        return StatusCode::NOT_FOUND.into_response();
     }
+
+    response.unwrap()
 }

--- a/web-api/src/main.rs
+++ b/web-api/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), CustomError> {
     let container = Arc::new(AppContainer::new().await);
 
     let mock_handler =
-        Arc::new(utils::mock_handler::MockEndpointsHandler::new(container.clone()).await?);
+        Arc::new(utils::mock_handler::DatabaseMockHandlerImpl::new(container.clone()).await?);
 
     let app = app
         .with(AddData::new(container))

--- a/web-api/src/utils/mock_handler.rs
+++ b/web-api/src/utils/mock_handler.rs
@@ -10,6 +10,14 @@ pub struct MockEndpointsHandler {
     pub caching: Arc<TemplateCachingImpl>,
 }
 
+pub trait MockEndpointsLoader {
+    fn load_mock_endpoints(&self) -> Result<(), CustomError>;
+}
+
+pub trait MockEndpointsProvider {
+    fn get_mock_endpoints(&self) -> Result<Vec<TemplateImpl>, CustomError>;
+}
+
 impl MockEndpointsHandler {
     pub async fn new(container: Arc<AppContainer>) -> Result<Self, CustomError> {
         let app_container = container.clone();

--- a/web-api/src/utils/mock_handler.rs
+++ b/web-api/src/utils/mock_handler.rs
@@ -6,7 +6,7 @@ use endpoint_handler::{
     endpoint_template::{Template, TemplateImpl},
     utils::path::first_scope,
 };
-use poem::{IntoResponse, Request, Response};
+use poem::{Request, Response};
 
 pub struct DatabaseMockHandlerImpl {
     caching: Arc<dyn TemplateCaching>,


### PR DESCRIPTION
* The Cache of templates will not load whole tempates into Cache when application first loaded right now.
* Instead, The Cache will load when user access mock endpoints.
* Load endpoint template by endpoint first scope each time.